### PR TITLE
PHPStan generics and PhpStorm metadata for ArrayType

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+// Fixes autocompletion for some of the ArrayType functions
+// @see https://www.jetbrains.com/help/phpstorm/ide-advanced-metadata.html
+
+namespace PHPSTORM_META {
+
+	use Consistence\Type\ArrayType\ArrayType;
+
+	override(ArrayType::findValue(0), elementType(0));
+	override(ArrayType::getValue(0), elementType(0));
+	override(ArrayType::findValueByCallback(0), elementType(0));
+	override(ArrayType::getValueByCallback(0), elementType(0));
+	override(ArrayType::filterByCallback(0), type(0));
+	override(ArrayType::filterValuesByCallback(0), type(0));
+	override(ArrayType::uniqueValues(0), type(0));
+	override(ArrayType::uniqueValuesByCallback(0), type(0));
+
+}

--- a/src/Type/ArrayType/ArrayType.php
+++ b/src/Type/ArrayType/ArrayType.php
@@ -177,6 +177,10 @@ class ArrayType extends \Consistence\ObjectPrototype
 	}
 
 	/**
+	 * @phpstan-template T
+	 * @phpstan-param T[] $haystack
+	 * @phpstan-return T|null
+	 *
 	 * @param mixed[] $haystack
 	 * @param int|string $key
 	 * @return mixed
@@ -191,6 +195,10 @@ class ArrayType extends \Consistence\ObjectPrototype
 	}
 
 	/**
+	 * @phpstan-template T
+	 * @phpstan-param T[] $haystack
+	 * @phpstan-return T
+	 *
 	 * @param mixed[] $haystack
 	 * @param int|string $key
 	 * @return mixed
@@ -244,6 +252,10 @@ class ArrayType extends \Consistence\ObjectPrototype
 	/**
 	 * Stops on first occurrence when callback(value) is trueish or returns null
 	 *
+	 * @phpstan-template T
+	 * @phpstan-param T[] $haystack
+	 * @phpstan-return T|null
+	 *
 	 * @param mixed[] $haystack
 	 * @param \Closure $callback
 	 * @return mixed
@@ -262,6 +274,10 @@ class ArrayType extends \Consistence\ObjectPrototype
 	/**
 	 * Stops on first occurrence when callback(value) is trueish or throws exception
 	 *
+	 * @phpstan-template T
+	 * @phpstan-param T[] $haystack
+	 * @phpstan-return T
+	 *
 	 * @param mixed[] $haystack
 	 * @param \Closure $callback
 	 * @return mixed
@@ -279,6 +295,10 @@ class ArrayType extends \Consistence\ObjectPrototype
 
 	/**
 	 * Filters arrays by callback(\Consistence\Type\ArrayType\KeyValuePair)
+	 *
+	 * @phpstan-template T
+	 * @phpstan-param T[] $haystack
+	 * @phpstan-return T[]
 	 *
 	 * @param mixed[] $haystack
 	 * @param \Closure $callback
@@ -300,6 +320,10 @@ class ArrayType extends \Consistence\ObjectPrototype
 
 	/**
 	 * Wrapper for PHP array_filter, executes loose comparison
+	 *
+	 * @phpstan-template T
+	 * @phpstan-param T[] $haystack
+	 * @phpstan-return T[]
 	 *
 	 * @param mixed[] $haystack
 	 * @param \Closure $callback
@@ -401,6 +425,10 @@ class ArrayType extends \Consistence\ObjectPrototype
 	/**
 	 * Mimics the behaviour of array_unique, but makes strict comparisons by default
 	 *
+	 * @phpstan-template T
+	 * @phpstan-param T[] $haystack
+	 * @phpstan-return T[]
+	 *
 	 * @param mixed[] $haystack
 	 * @param bool $strict
 	 * @return mixed[] new array with unique values
@@ -420,6 +448,10 @@ class ArrayType extends \Consistence\ObjectPrototype
 	/**
 	 * Returns new array with unique values using callback(valueA, valueB),
 	 * values are same if callback returns trueish value
+	 *
+	 * @phpstan-template T
+	 * @phpstan-param T[] $haystack
+	 * @phpstan-return T[]
 	 *
 	 * @param mixed[] $haystack
 	 * @param \Closure $callback


### PR DESCRIPTION
This was originally proposed in https://github.com/consistence/consistence/pull/46

----

PHPStan can use extra PHPDocs for determining the return types (see https://phpstan.org/blog/generics-in-php-using-phpdocs) so it can detect potential errors when calling methods on values returned from ArrayType functions.

PhpStorm parses special `.phpstorm.meta.php` file (see https://www.jetbrains.com/help/phpstorm/ide-advanced-metadata.html) to provide autocompletion on values returned from ArrayType functions.

### Notes

* This PR is proof-of-contept as both features can be theoretically used in more classes (`KeyValuePair`, enums?, etc.)
* The `.phpstorm.meta.php` can be easily tested just by copying anywhere in a project using Consistence
